### PR TITLE
Warn / Error for Mac OS

### DIFF
--- a/python/gvgai/gvgai/client/iosocket.py
+++ b/python/gvgai/gvgai/client/iosocket.py
@@ -8,7 +8,6 @@ from struct import pack_into, unpack_from
 class IOSocket:
 
     def __init__(self, client_only=False):
-        if 
         self.HEADER_SIZE = 13
         self.BUFFER_SIZE = 8192*10
         self.hostname, self.port = self.getOpenAddress()

--- a/python/gvgai/gvgai/client/iosocket.py
+++ b/python/gvgai/gvgai/client/iosocket.py
@@ -8,6 +8,7 @@ from struct import pack_into, unpack_from
 class IOSocket:
 
     def __init__(self, client_only=False):
+        if 
         self.HEADER_SIZE = 13
         self.BUFFER_SIZE = 8192*10
         self.hostname, self.port = self.getOpenAddress()
@@ -27,7 +28,9 @@ class IOSocket:
             try:
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-                self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)
+                if not 'darwin' in sys.platform():
+                    self._logger.warn('Attempting to run without TCP_QUICKACK. Consider running instead on unix.')
+                    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)
                 self.socket.connect((self.hostname, self.port))
                 self.connected = True
                 self._logger.debug("Client connected to server [OK]")

--- a/python/gvgai/gvgai/client/iosocket.py
+++ b/python/gvgai/gvgai/client/iosocket.py
@@ -27,7 +27,7 @@ class IOSocket:
             try:
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-                if not 'darwin' in sys.platform():
+                if not 'darwin' in sys.platform:
                     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)
                 else:
                     self._logger.warn('Attempting to run without TCP_QUICKACK. Consider running instead on unix!')

--- a/python/gvgai/gvgai/client/iosocket.py
+++ b/python/gvgai/gvgai/client/iosocket.py
@@ -28,8 +28,9 @@ class IOSocket:
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 if not 'darwin' in sys.platform():
-                    self._logger.warn('Attempting to run without TCP_QUICKACK. Consider running instead on unix.')
                     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_QUICKACK, 1)
+                else:
+                    self._logger.warn('Attempting to run without TCP_QUICKACK. Consider running instead on unix!')
                 self.socket.connect((self.hostname, self.port))
                 self.connected = True
                 self._logger.debug("Client connected to server [OK]")


### PR DESCRIPTION
Great repo! Seems this isn't as out of the box for a Mac :(. 

The IO socket fails silently on MacOS, so disabling the statement and showing a warning that the user is entering uncharted territory! https://github.com/Bam4d/GVGAI_GYM/blob/master/python/gvgai/gvgai/client/iosocket.py#L28

Setting a print statement for the exception gives:

> trying to connect to socket with host 127.0.0.1 port 52071                                                                               
> error connecting to socket                                                                                                               
> module 'socket' has no attribute 'TCP_QUICKACK'                                                                                          
> trying to connect to socket with host 127.0.0.1 port 52071                                                                               
> error connecting to socket                                          
> module 'socket' has no attribute 'TCP_QUICKACK'                                                                                          
> trying to connect to socket with host 127.0.0.1 port 52071                                                                               
> error connecting to socket                                                                                                               
> module 'socket' has no attribute 'TCP_QUICKACK'                                                                                          
> trying to connect to socket with host 127.0.0.1 port 52071                                                                               
> error connecting to socket                                                                                                               
> module 'socket' has no attribute 'TCP_QUICKACK'                                                                                          
> trying to connect to socket with host 127.0.0.1 port 52071
